### PR TITLE
Bareos 23.0.4: Fedora 40, Ubuntu 2404 support

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -31,13 +31,13 @@ jobs:
           - image: "debian"
             tag: "bullseye"
           - image: "fedora"
-            tag: "38"
-          - image: "fedora"
             tag: "39"
-          - image: "ubuntu"
-            tag: "focal"
+          - image: "fedora"
+            tag: "latest"
           - image: "ubuntu"
             tag: "jammy"
+          - image: "ubuntu"
+            tag: "latest"
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -1,20 +1,15 @@
 ---
-#
-# Ansible managed
-#
 
-name: "TODO 2 Issue"
-
+name: "Run TODO to Issue"
 on:
   push:
-
 jobs:
   build:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@master"
+      - uses: "actions/checkout@v3"
       - name: "TODO to Issue"
-        uses: "alstr/todo-to-issue-action@v2.3"
+        uses: "alstr/todo-to-issue-action@v4"
         id: "todo"
         with:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,12 +14,12 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - "38"
         - "39"
+        - "40"
     - name: Ubuntu
       versions:
         - jammy
-        - focal
+        - noble
 
   galaxy_tags:
     - backup


### PR DESCRIPTION
* Run tests against new distro releases. Fixes #3 
* Use Ubuntu latest to run CI jobs on