### PR TITLE
fix(ci): pass adfinisbot token explicitely

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -11,4 +11,5 @@ on:
 jobs:
   semantic-release:
     uses: adfinis/github-workflows-bareos/.github/workflows/semantic-release.yaml@v0.1.0
-    secrets: inherit
+    secrets:
+      ADFINISBOT_GITHUB_TOKEN: ${{ secrets.ADFINISBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Seems like this is needed because ADFINISBOT_GITHUB_TOKEN isn't organization wide.