### PR TITLE
fix: ansible_managed in templates/directors.ini.j2

### DIFF
--- a/templates/directors.ini.j2
+++ b/templates/directors.ini.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+; {{ ansible_managed }}
 ;
 ; Bareos WebUI Configuration File
 ;


### PR DESCRIPTION
`{{ ansible_managed | comment }}` used "#" instead of ";", which breaks the config.